### PR TITLE
Fixing authlib-injector version (temporarily solution)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,6 @@ on:
     branches: [ develop ]
   pull_request:
     branches: [ develop ]
-  workflow_dispatch:
 
 jobs:
   build-linux:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,7 @@ on:
     branches: [ develop ]
   pull_request:
     branches: [ develop ]
+  workflow_dispatch:
 
 jobs:
   build-linux:

--- a/launcher/minecraft/launch/InjectAuthlib.cpp
+++ b/launcher/minecraft/launch/InjectAuthlib.cpp
@@ -18,7 +18,8 @@ void InjectAuthlib::executeTask()
         return;
     }
 
-    auto latestVersionInfo = QString("https://authlib-injector.yushi.moe/artifact/latest.json");
+    auto latestVersionInfo = QString("https://authlib-injector.yushi.moe/artifact/47.json");
+    // Not the latest, modifing because of the breaking changes on 1.2.0
     auto netJob = new NetJob("Injector versions info download", APPLICATION->network());
     MetaEntryPtr entry = APPLICATION->metacache()->resolveEntry("injectors", "version.json");
     if (!m_offlineMode)


### PR DESCRIPTION
Since [#172 or 1.2.0](https://github.com/yushijinhun/authlib-injector/pull/172) of authlib-injector, there was breaking changes of how the authentication works on both ends. This repo didn't make any changes to the [AuthServer.cpp](https://github.com/UltimMC/Launcher/blob/develop/launcher/AuthServer.cpp) for some time, which means that some people are having problems connecting to some servers 1.19.1 and above. This pull request should resolve this issue, though temporarily, until someone updates the [AuthServer.cpp](https://github.com/UltimMC/Launcher/blob/develop/launcher/AuthServer.cpp).