### PR TITLE
initialize MinecraftAccount::data.minecraftProfile.id

### DIFF
--- a/launcher/minecraft/auth/MinecraftAccount.cpp
+++ b/launcher/minecraft/auth/MinecraftAccount.cpp
@@ -58,6 +58,7 @@ MinecraftAccountPtr MinecraftAccount::createFromUsername(const QString &username
     account->data.type = AccountType::Mojang;
     account->data.yggdrasilToken.extra["userName"] = username;
     account->data.yggdrasilToken.extra["clientToken"] = QUuid::createUuid().toString().remove(QRegExp("[{}-]"));
+    account->data.minecraftProfile.id = account->data.internalId;
     return account;
 }
 


### PR DESCRIPTION
this is very minor but it makes running 1.20.2 possible and therefore fixes #303, #308, and #309. in spite of this it does require all profiles to be deleted and recreated (not just refreshed)