### PR TITLE
Small fix for IPV6 only + DDNS Server

### DIFF
--- a/launcher/minecraft/auth/providers/LocalAuthProvider.h
+++ b/launcher/minecraft/auth/providers/LocalAuthProvider.h
@@ -31,12 +31,12 @@ public:
 
     QString injectorEndpoint()
     {
-        return ((QString)"http://localhost:%1").arg(m_authServer->port());
+        return ((QString)"http://127.0.0.1:%1").arg(m_authServer->port());
     };
 
     QString authEndpoint()
     {
-        return ((QString) "http://localhost:%1/auth/").arg(m_authServer->port());
+        return ((QString) "http://127.0.0.1:%1/auth/").arg(m_authServer->port());
     };
 
     virtual bool useYggdrasil()


### PR DESCRIPTION
Hello,
My ISP only lets me use IPV6 for my server with my friends and i wanted to setup a DDNS hostname so i can update the IPV6 address seamlessly for my friends, but since the DDNS is always both an IPV4 and an IPV6 record and never IPV6 only i have to use the -Djava.net.preferIPv6Addresses=true Java argument since Minecraft always defaults to the IPV4 address (which is blocked) without it.

But then the Launcher doesn't work because of the use of localhost (that defaults to ::1 in IPV6)  instead of 127.0.0.1 in the 
launcher/minecraft/auth/providers/LocalAuthProvider.h used for the authlib injector's authentication server.

Fixed the two line of code and rebuilt the project to test and now it works perfectly, hope this will end up in an update!
Thank you.