### PR TITLE
Debian 12 compatibility

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build-linux:
     name: build-linux
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@main

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build-linux:
     name: build-linux
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@main


### PR DESCRIPTION
Latest build cannot run on Debian 12 (version `GLIBC_2.38' not found), editing the workflow from ubuntu-latest to ubuntu-20.04 fixes the issue. Based on https://github.com/Genymobile/scrcpy/issues/5689